### PR TITLE
feat: support llmman as an Ollama-compatible backend via LLMMAN_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ LLocal's builds are unsigned at the moment, meaning there will be an unknown pub
 
 The link to the mac universal build is [this](https://github.com/kartikm7/llocal/releases/download/v1.0.0-beta.5/LLocal-1.0.0-beta.5-mac.zip).
 
+## Using with llmman
+
+[llmman](https://github.com/llmmanorg/llmman) is a local model runner that serves the Ollama API on port 17434. Set `LLMMAN_HOST` (`[host][:port]`, defaults to `localhost:17434`) before launching to use it instead of Ollama:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+llmman pull gemma4
+llmman pull all-minilm
+llmman serve
+LLMMAN_HOST=127.0.0.1:17434 npm run dev
+```
+
+When `LLMMAN_HOST` is set the Ollama install/serve flow is skipped, so Ollama does not need to be installed.
+
 ## Project Setup
 
 LLocal is an Electron application with React and TypeScript.

--- a/src/main/ollama-binaries.ts
+++ b/src/main/ollama-binaries.ts
@@ -4,6 +4,7 @@ import path from 'path'
 import fs from 'fs'
 import { exec } from 'child_process'
 import { downloadDirectory } from '.'
+import { usingLlmman } from './utils/host'
 
 type binary = {
   name: string
@@ -22,6 +23,8 @@ export const binaryNames = {
 }
 
 export function checkOllama(): Promise<boolean> {
+  // llmman users run `llmman serve` themselves; Ollama need not be installed
+  if (usingLlmman) return Promise.resolve(true)
   return new Promise((resolve) => {
     exec('ollama serve', (error) => {
       // if check is true, that means there's an error

--- a/src/main/puppeteer.ts
+++ b/src/main/puppeteer.ts
@@ -1,4 +1,5 @@
 import { OllamaEmbeddings } from '@langchain/community/embeddings/ollama'
+import { host } from './utils/host'
 import { MemoryVectorStore } from 'langchain/vectorstores/memory'
 // import { load } from 'cheerio'
 import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter'
@@ -85,7 +86,7 @@ export async function puppeteerSearch(
 
   // generating embeddings for the same
   const embeddings = new OllamaEmbeddings({
-    baseUrl: 'http://127.0.0.1:11434',
+    baseUrl: host,
     model: 'all-minilm'
   })
 

--- a/src/main/utils/host.ts
+++ b/src/main/utils/host.ts
@@ -1,0 +1,7 @@
+// Base URL of the Ollama-compatible server: llmman (https://github.com/llmmanorg/llmman)
+// when LLMMAN_HOST ([host][:port]) is set, otherwise Ollama's default.
+export const usingLlmman = process.env.LLMMAN_HOST !== undefined
+const [hostname, port] = (process.env.LLMMAN_HOST ?? '').replace(/^https?:\/\//, '').split(':')
+export const host = usingLlmman
+  ? `http://${hostname || 'localhost'}:${port || '17434'}`
+  : 'http://localhost:11434'

--- a/src/main/utils/rag-utils.ts
+++ b/src/main/utils/rag-utils.ts
@@ -7,6 +7,7 @@ import { readdirSync, rm } from 'fs'
 import path from 'path'
 import { documentsDirectory } from '..'
 import i18n from '../lib/localization/i18n'
+import { host } from './host'
 // import { AutoModel } from '@huggingface/transformers'
 
 interface GetFile {
@@ -59,7 +60,7 @@ export async function getSelectedFiles(): Promise<GetFile> {
 
 export const saveVectorDb = async (docs: Document[], saveDirectory: string): Promise<boolean> => {
   const embeddings = new OllamaEmbeddings({
-    baseUrl: 'http://127.0.0.1:11434',
+    baseUrl: host,
     model: 'all-minilm'
   })
 
@@ -154,7 +155,7 @@ export const similaritySearch = async (
   prompt: string,
 ): Promise<RagReturn> => {
   const embeddings = new OllamaEmbeddings({
-    baseUrl: 'http://127.0.0.1:11434',
+    baseUrl: host,
     model: 'all-minilm'
   })
   const allResults = await Promise.all(selectedKnowledge.map(async (db) => {

--- a/src/main/websearch.ts
+++ b/src/main/websearch.ts
@@ -2,6 +2,7 @@
 // import DDG from "duck-duck-scrape"
 import { RecursiveCharacterTextSplitter } from 'langchain/text_splitter'
 import { OllamaEmbeddings } from '@langchain/community/embeddings/ollama'
+import { host } from './utils/host'
 import { MemoryVectorStore } from 'langchain/vectorstores/memory'
 import {
   search,
@@ -55,7 +56,7 @@ export async function webSearch(searchQuery: string): Promise<webSearchType> {
 
   // generating embeddings for the same
   const embeddings = new OllamaEmbeddings({
-    baseUrl: 'http://127.0.0.1:11434',
+    baseUrl: host,
     model: 'all-minilm'
   })
   const vectorStore = await MemoryVectorStore.fromDocuments(allSplits, embeddings)

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -20,6 +20,7 @@ declare global {
   interface Window {
     electron: ElectronAPI
     api: {
+      host: string,
       checkingOllama: () => Promise<boolean>,
       checkingBinaries: () => Promise<boolean>,
       checkingBinarySize: () => Promise<boolean>,

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron'
+import { host } from '../main/utils/host'
 // import { electronAPI } from '@electron-toolkit/preload'
 
 interface webSearchType {
@@ -8,6 +9,8 @@ interface webSearchType {
 
 // Custom APIs for renderer
 const api = {
+  // base url of the Ollama-compatible server (Ollama, or llmman when LLMMAN_HOST is set)
+  host,
   checkingOllama: (): Promise<boolean> => ipcRenderer.invoke('checkingOllama'),
   checkingBinaries: (): Promise<boolean> => ipcRenderer.invoke('checkingBinaries'),
   checkingBinarySize: (): Promise<boolean> => ipcRenderer.invoke('checkingBinarySize'),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -7,7 +7,7 @@
 
     <!-- <script src="https://unpkg.com/react-scan/dist/auto.global.js"></script> -->
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'self';  connect-src 'self' http://localhost:11434 http://127.0.0.1:11434; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; img-src 'self' data:; media-src blob:" />
+    content="default-src 'self';  connect-src 'self' http://localhost:11434 http://127.0.0.1:11434 http://localhost:17434 http://127.0.0.1:17434; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval'; img-src 'self' data:; media-src blob:" />
 </head>
 
 <body class="">

--- a/src/renderer/src/utils/ollama.ts
+++ b/src/renderer/src/utils/ollama.ts
@@ -2,10 +2,11 @@ import { Ollama } from 'ollama/browser'
 import { toast } from 'sonner'
 import { t } from './utils'
 
-export const ollama = new Ollama({ host: 'http://localhost:11434' })
+// Ollama by default, or llmman when LLMMAN_HOST is set (see src/main/utils/host.ts)
+export const ollama = new Ollama({ host: window.api.host })
 // a new ollama client is needed so that when aborting a pull, the on-going chat does not get aborted aswell or vice-versa
 // this is also a hygeine practice, where all functions other than chat should use helper-client just to decouple the use-cases
-export const helperOllama = new Ollama({ host: 'http://localhost:11434' })
+export const helperOllama = new Ollama({ host: window.api.host })
 
 async function installOllama(): Promise<void> {
   toast.info(t("Please be patient with the Ollama installation, there are background process running to get the Ollama installer up and running for you! (Should take about a mintue)"))


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), a local model runner that serves the Ollama API on port 17434, as a drop-in backend.

- `src/main/utils/host.ts` (new): one shared constant that honours `LLMMAN_HOST` (`[host][:port]`, default `localhost:17434`) and falls back to Ollama's `http://localhost:11434` when unset, so nothing changes for existing users.
- Preload exposes `host` on `window.api`; both `Ollama` clients in `src/renderer/src/utils/ollama.ts` use it instead of the hardcoded `11434`.
- `OllamaEmbeddings` in `rag-utils.ts`, `websearch.ts` and `puppeteer.ts` use the same constant, so chat-with-files and web search follow the chat backend.
- Renderer CSP `connect-src` additionally allows `localhost:17434` / `127.0.0.1:17434`.
- `checkOllama()` resolves `true` when `LLMMAN_HOST` is set, skipping the Ollama download/install flow. README gets a short "Using with llmman" section.

**Testing:** `tsc --noEmit` for `tsconfig.node.json` and `tsconfig.web.json` (only the pre-existing `kokoro-js` error remains, none in touched files); `eslint` on changed files clean. Not run against a live llmman or Ollama server.

> AI-assisted, reviewed before submitting.
